### PR TITLE
Serde's for parquet

### DIFF
--- a/pymatgen/io/validation/check_common_errors.py
+++ b/pymatgen/io/validation/check_common_errors.py
@@ -85,7 +85,7 @@ class CheckCommonErrors(BaseValidator):
         ):
             # Response function calculations are non-self-consistent: only one ionic step, no electronic SCF
             if vasp_files.user_input.incar.get("LEPSILON", self.vasp_defaults["LEPSILON"].value):
-                final_esteps = vasp_files.vasprun.ionic_steps[-1]["electronic_steps"]
+                final_esteps = vasp_files.vasprun.ionic_steps[-1].electronic_steps
                 to_check = {"e_wo_entrp", "e_fr_energy", "e_0_energy"}
 
                 for i in range(len(final_esteps)):
@@ -98,7 +98,7 @@ class CheckCommonErrors(BaseValidator):
 
             else:
                 conv_steps = [
-                    len(ionic_step["electronic_steps"])
+                    len(ionic_step.electronic_steps)
                     < vasp_files.user_input.incar.get("NELM", self.vasp_defaults["NELM"].value)
                     for ionic_step in vasp_files.vasprun.ionic_steps
                 ]
@@ -190,7 +190,7 @@ class CheckCommonErrors(BaseValidator):
 
         skip = abs(vasp_files.user_input.incar.get("NELMDL", self.vasp_defaults["NELMDL"].value)) - 1
 
-        energies = [d["e_fr_energy"] for d in vasp_files.vasprun.ionic_steps[-1]["electronic_steps"]]
+        energies = [d.e_fr_energy for d in vasp_files.vasprun.ionic_steps[-1].electronic_steps]
         if len(energies) > skip:
             cur_max_gradient = np.max(np.gradient(energies)[skip:])
             cur_max_gradient_per_atom = cur_max_gradient / vasp_files.user_input.structure.num_sites

--- a/pymatgen/io/validation/common.py
+++ b/pymatgen/io/validation/common.py
@@ -9,7 +9,16 @@ import json
 from monty.serialization import loadfn
 import os
 from pathlib import Path
-from pydantic import BaseModel, Field, model_validator, model_serializer, PrivateAttr, PlainSerializer, BeforeValidator
+from pydantic import (
+    BaseModel,
+    Field,
+    model_validator,
+    model_serializer,
+    PrivateAttr,
+    PlainSerializer,
+    BeforeValidator,
+    RootModel,
+)
 from typing import TYPE_CHECKING, Any, Annotated, TypeAlias
 
 from pymatgen.core import Structure
@@ -52,6 +61,14 @@ StructureType: TypeAlias = Annotated[
     BeforeValidator(lambda x: _msonable_from_str(x, Structure)),
     PlainSerializer(lambda x: json.dumps(x.as_dict()), return_type=str),
 ]
+
+
+class _MsonStrType(RootModel):
+    root: str
+
+
+for pmg_obj in (Incar, Kpoints, Structure):
+    setattr(pmg_obj, "__type_adapter__", _MsonStrType)
 
 
 class ValidationError(Exception):

--- a/pymatgen/io/validation/common.py
+++ b/pymatgen/io/validation/common.py
@@ -115,6 +115,7 @@ class LightOutcar(BaseModel):
 
 
 class LightElectronicStep(BaseModel):
+    """Lightweight representation of electronic step data from VASP."""
 
     e_0_energy: float | None = None
     e_fr_energy: float | None = None
@@ -123,6 +124,7 @@ class LightElectronicStep(BaseModel):
 
 
 class LightIonicStep(BaseModel):
+    """Lightweight representation of ionic step data from VASP."""
 
     e_0_energy: float | None = None
     e_fr_energy: float | None = None

--- a/pymatgen/io/validation/common.py
+++ b/pymatgen/io/validation/common.py
@@ -17,9 +17,8 @@ from pydantic import (
     PrivateAttr,
     PlainSerializer,
     BeforeValidator,
-    RootModel,
 )
-from typing import TYPE_CHECKING, Any, Annotated, TypeAlias
+from typing import TYPE_CHECKING, Any, Annotated, TypeAlias, TypeVar
 
 from pymatgen.core import Structure
 from pymatgen.io.vasp.inputs import POTCAR_STATS_PATH, Incar, Kpoints, Poscar, Potcar, PmgVaspPspDirError
@@ -44,31 +43,26 @@ def _msonable_from_str(obj: Any, cls: type[MSONable]) -> MSONable:
     return obj
 
 
+IncarTypeVar = TypeVar("IncarTypeVar", Incar, str)
 IncarType: TypeAlias = Annotated[
-    Incar,
+    IncarTypeVar,
     BeforeValidator(lambda x: _msonable_from_str(x, Incar)),
     PlainSerializer(lambda x: json.dumps(x.as_dict()), return_type=str),
 ]
 
+KpointsTypeVar = TypeVar("KpointsTypeVar", Kpoints, str)
 KpointsType: TypeAlias = Annotated[
-    Kpoints,
+    KpointsTypeVar,
     BeforeValidator(lambda x: _msonable_from_str(x, Kpoints)),
     PlainSerializer(lambda x: json.dumps(x.as_dict()), return_type=str),
 ]
 
+StructureTypeVar = TypeVar("StructureTypeVar", Structure, str)
 StructureType: TypeAlias = Annotated[
-    Structure,
+    StructureTypeVar,
     BeforeValidator(lambda x: _msonable_from_str(x, Structure)),
     PlainSerializer(lambda x: json.dumps(x.as_dict()), return_type=str),
 ]
-
-
-class _MsonStrType(RootModel):
-    root: str
-
-
-for pmg_obj in (Incar, Kpoints, Structure):
-    setattr(pmg_obj, "__type_adapter__", _MsonStrType)
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
In line with emmet's transition to parquet native data structures, enforces stronger typing / de-/serialization for MSONables which are parquet unfriendly