### PR TITLE
Bump python version + precommit

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Build
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     runs-on: ${{ matrix.os }}
 
@@ -36,8 +36,3 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
-    # - uses: codecov/codecov-action@v1
-    #   if: matrix.python-version == 3.10
-    #   with:
-    #     token: ${{ secrets.CODECOV_TOKEN }}
-    #     file: ./coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,5 @@
 exclude: ^(docs|.*test_files|cmd_line|dev_scripts|.github)
 
-default_language_version:
-  python: python3.11
-
 ci:
   autoupdate_schedule: monthly
   skip: [flake8, autoflake, mypy]
@@ -10,31 +7,25 @@ ci:
 repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]
 
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 26.3.1
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  #- repo: https://github.com/asottile/pyupgrade
-  #  rev: v3.15.1
-  #  hooks:
-  #    - id: pyupgrade
-  #      args: [--py38-plus]
-
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.0
+    rev: v2.3.3
     hooks:
       - id: autoflake
         args:
@@ -45,7 +36,7 @@ repos:
           - --ignore-init-module-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.20.2
     hooks:
       - id: mypy
         files: ^pymatgen/
@@ -55,7 +46,7 @@ repos:
         additional_dependencies: ['types-requests','pydantic>=2.10.0']
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
         args:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,7 +10,6 @@ from pymatgen.io.validation.common import ValidationError, VaspFiles, PotcarSumm
 
 from conftest import vasp_calc_data, incar_check_list, set_fake_potcar_dir
 
-
 ### TODO: add tests for many other MP input sets (e.g. MPNSCFSet, MPNMRSet, MPScanRelaxSet, Hybrid sets, etc.)
 ### TODO: add check for an MP input set that uses an IBRION other than [-1, 1, 2]
 ### TODO: add in check for MP set where LEFG = True


### PR DESCRIPTION
- [NEP 29 compliance](https://numpy.org/neps/nep-0029-deprecation_policy.html): test py 3.12, 3.13, and 3.14
- Update precommit 