### PR TITLE
Fix: validate r2SCAN calcs against MP24 input sets

### DIFF
--- a/pymatgen/io/validation/common.py
+++ b/pymatgen/io/validation/common.py
@@ -522,7 +522,18 @@ class VaspFiles(BaseModel):
                 set_name = None
             elif self.run_type in ("relax", "static"):
                 set_name = f"MP{self.run_type.capitalize()}Set"
-        elif self.functional in ("pbesol", "scan", "r2scan", "hse06"):
+        elif self.functional == "r2scan":
+            # MP's current r2SCAN protocol uses the MP24 input sets (MP24RelaxSet /
+            # MP24StaticSet), which set GGA_COMPAT=False. The legacy MPScan*Set sets
+            # leave GGA_COMPAT unset (defaulting to True), so validating an MP24 r2SCAN
+            # calculation against them spuriously fails the GGA_COMPAT check. This
+            # matches VASP_DEFAULT_INPUT_SETS, which already maps the r2SCAN calc types
+            # to the MP24 sets.
+            if self.run_type == "relax":
+                set_name = "MP24RelaxSet"
+            elif self.run_type == "static":
+                set_name = "MP24StaticSet"
+        elif self.functional in ("pbesol", "scan", "hse06"):
             set_name = f"MPScan{self.run_type.capitalize()}Set"
 
         if set_name is None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -598,3 +598,41 @@ def test_site_properties(test_dir):
     )
     vd = VaspValidator.from_vasp_input(vasp_files=vf)
     assert any("non-zero velocities" in warning.lower() for warning in vd.warnings)
+
+
+@pytest.mark.parametrize(
+    "run_type,expected_set",
+    [("relax", "MP24RelaxSet"), ("static", "MP24StaticSet")],
+)
+def test_r2scan_uses_mp24_input_set(run_type, expected_set):
+    """r2SCAN calcs must validate against the MP24 sets, not the legacy MPScan sets.
+
+    Regression test for the GGA_COMPAT false-positive: the MP24 input sets set
+    GGA_COMPAT=False, but MPScanRelaxSet/MPScanStaticSet leave it unset (default
+    True), so an MP24 r2SCAN calc was spuriously flagged. VASP_DEFAULT_INPUT_SETS
+    already maps the r2SCAN calc types to the MP24 sets; the resolver must agree.
+    """
+    from pymatgen.io.validation.common import VaspFiles
+
+    vf = VaspFiles.model_construct(functional="r2scan", run_type=run_type)
+    assert vf.set_valid_input_set_name() == expected_set
+
+
+def test_r2scan_relax_passes_gga_compat_check():
+    """An MP24RelaxSet-generated r2SCAN relax must not fail the GGA_COMPAT check."""
+    from pymatgen.core import Lattice
+    from pymatgen.io.vasp.sets import MP24RelaxSet
+
+    from pymatgen.io.validation.common import VaspFiles, VaspInputSafe
+
+    si = Structure.from_spacegroup(
+        "Fd-3m", Lattice.cubic(5.468), ["Si"], [[0.0, 0.0, 0.0]]
+    ).get_primitive_structure()
+    vf = VaspFiles(user_input=VaspInputSafe.from_vasp_input_set(MP24RelaxSet(structure=si)))
+
+    assert vf.functional == "r2scan"
+    assert vf.run_type == "relax"
+    assert vf.valid_input_set_name == "MP24RelaxSet"
+
+    reasons, _ = VaspValidator.run_checks(vf, fast=False)
+    assert not any("GGA_COMPAT" in reason for reason in reasons), reasons


### PR DESCRIPTION
set_valid_input_set_name resolved every r2SCAN calc to MPScan{RunType}Set (the legacy SCAN sets), regardless of VASP_DEFAULT_INPUT_SETS already mapping the r2SCAN calc types to the MP24 sets. MPScanRelaxSet/MPScanStaticSet leave GGA_COMPAT unset (defaulting to True), while the MP24 sets deliberately set GGA_COMPAT=False, so any MP24-generated r2SCAN calculation spuriously failed the GGA_COMPAT INCAR check.

Route r2SCAN relax/static to MP24RelaxSet/MP24StaticSet, mirroring the pbe branch (relax/static resolve explicitly; anything else falls through to the 'could not determine input set' error). pbesol/scan/hse06 continue to use the MPScan sets.

Adds regression tests covering both the resolver output and the end-to-end GGA_COMPAT check on an MP24RelaxSet-generated r2SCAN relax.